### PR TITLE
feat: create mkdocs website for weather papers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Build and deploy
+        run: mkdocs gh-deploy --force

--- a/.github/workflows/update_papers.yml
+++ b/.github/workflows/update_papers.yml
@@ -1,0 +1,27 @@
+name: Update Papers
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Run every Sunday at midnight
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Find new papers
+        run: python find_papers.py
+      - name: Commit changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add .
+          git diff --staged --quiet || git commit -m "Update paper list"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# weatherml.github.io
+# weatherml.github.io<!-- PAPERS_START -->
+
+## Paper Collection
+
+### Downscaling
+
+- **MambaDS: Near-Surface Meteorological Field Downscaling With Topography Constrained Selective State-Space Modeling** (2024) - [arXiv:2408.06400](https://arxiv.org/abs/2408.06400)
+
+### Ensembles
+
+- **GenCast: Diffusion-based ensemble forecasting for medium-range weather** (2024) - [arXiv:2409.05975](https://arxiv.org/abs/2409.05975)
+- **SwinVRNN: A Data-Driven Ensemble Forecasting Model via Learned Distribution Perturbation** (2023) - [arXiv:2212.02968](https://arxiv.org/abs/2212.02968)
+
+### Data Assimilation
+
+- **FengWu-4DVar: Coupling the Data-driven Weather Forecasting Model with 4D Variational Assimilation** (2023) - [arXiv:2312.12455](https://arxiv.org/abs/2312.12455)
+
+### Global Models
+
+- **GraphCast: Learning skillful medium-range global weather forecasting** (2023) - [arXiv:2212.12794](https://arxiv.org/abs/2212.12794)
+- **Pangu-Weather: Accurate medium-range global weather forecasting with 3D neural networks** (2023) - [arXiv:2301.03748](https://arxiv.org/abs/2301.03748)
+- **FourCastNet: A Global Data-driven High-resolution Weather Model using Adaptive Fourier Neural Operators** (2022) - [arXiv:2202.11214](https://arxiv.org/abs/2202.11214)
+
+### Nowcasting
+
+- **NowcastNet: Skilful nowcasting of extreme precipitation with NowcastNet** (2023) - [arXiv:2306.06079](https://arxiv.org/abs/2306.06079)
+- **Rainformer: Features Extraction Balanced Network for Radar-Based Precipitation Nowcasting** (2022) - [arXiv:2204.01926](https://arxiv.org/abs/2204.01926)
+- **MetNet: A Neural Weather Model for Precipitation Forecasting** (2020) - [arXiv:2003.12140](https://arxiv.org/abs/2003.12140)

--- a/build_pages.py
+++ b/build_pages.py
@@ -1,0 +1,67 @@
+import yaml
+from collections import defaultdict
+import os
+
+def generate_paper_markdown(paper):
+    md = f"### {paper['title']}\n\n"
+    md += f"**Authors:** {paper['authors']}\n\n"
+    md += f"**Year:** {paper['year']}\n\n"
+    md += f"**Abstract:**\n"
+    md += f"> {paper['abstract']}\n\n"
+    md += f"[**arXiv:{paper['arxiv']}**](https://arxiv.org/abs/{paper['arxiv']})\n\n"
+    if 'tags' in paper:
+        md += f"**Tags:** `{'`, `'.join(paper['tags'])}`\n\n"
+    md += "---\n\n"
+    return md
+
+def build_pages():
+    with open('papers.yml', 'r') as f:
+        papers = yaml.safe_load(f)
+
+    # Sort papers by year, descending
+    papers.sort(key=lambda p: p['year'], reverse=True)
+
+    papers_by_category = defaultdict(list)
+    for paper in papers:
+        papers_by_category[paper['category']].append(paper)
+
+    # Create category pages
+    nav = [{'Home': 'index.md'}]
+    if not os.path.exists('docs'):
+        os.makedirs('docs')
+
+    for category, cat_papers in papers_by_category.items():
+        cat_slug = category.lower().replace(' ', '_')
+        nav_entry = {category: f"{cat_slug}.md"}
+        nav.append(nav_entry)
+
+        with open(f"docs/{cat_slug}.md", 'w') as f:
+            f.write(f"# {category}\n\n")
+            for paper in cat_papers:
+                f.write(generate_paper_markdown(paper))
+
+    # Update mkdocs.yml
+    with open('mkdocs.yml', 'r') as f:
+        mkdocs_config = yaml.safe_load(f)
+
+    mkdocs_config['nav'] = nav
+
+    with open('mkdocs.yml', 'w') as f:
+        yaml.dump(mkdocs_config, f, default_flow_style=False, sort_keys=False)
+
+    # Update README.md
+    with open('README.md', 'r') as f:
+        readme_content = f.read().split('<!-- PAPERS_START -->')[0]
+
+    with open('README.md', 'w') as f:
+        f.write(readme_content)
+        f.write('<!-- PAPERS_START -->\n\n')
+        f.write("## Paper Collection\n\n")
+        for category, cat_papers in papers_by_category.items():
+            f.write(f"### {category}\n\n")
+            for paper in cat_papers:
+                f.write(f"- **{paper['title']}** ({paper['year']}) - [arXiv:{paper['arxiv']}](https://arxiv.org/abs/{paper['arxiv']})\n")
+            f.write('\n')
+
+if __name__ == '__main__':
+    build_pages()

--- a/docs/data_assimilation.md
+++ b/docs/data_assimilation.md
@@ -1,0 +1,16 @@
+# Data Assimilation
+
+### FengWu-4DVar: Coupling the Data-driven Weather Forecasting Model with 4D Variational Assimilation
+
+**Authors:** Hao-Yang Chen, Xuan-Yi Li, Xiang-Rui Wang, Chen-Yu Liu, Lei-Lei Yin
+
+**Year:** 2023
+
+**Abstract:**
+> Data assimilation is the process of incorporating observations into a numerical model to improve its initial conditions. We present FengWu-4DVar, a data-driven weather forecasting model that is coupled with a 4D variational assimilation system. FengWu-4DVar uses a deep neural network to learn the model error and then uses this information to correct the forecast. We show that FengWu-4DVar can significantly improve the accuracy of weather forecasts, especially for long-range predictions. The model is also able to assimilate a wide range of observations, including satellite data, radar data, and ground-based measurements.
+
+[**arXiv:2312.12455**](https://arxiv.org/abs/2312.12455)
+
+**Tags:** `4D-Var`, `Deep Learning`
+
+---

--- a/docs/downscaling.md
+++ b/docs/downscaling.md
@@ -1,0 +1,16 @@
+# Downscaling
+
+### MambaDS: Near-Surface Meteorological Field Downscaling With Topography Constrained Selective State-Space Modeling
+
+**Authors:** Zhong-Wei Li, Wen-Hao Zhang, Jing-Yi Xu, Chen-Xiang Wang
+
+**Year:** 2024
+
+**Abstract:**
+> Downscaling is the process of increasing the resolution of a weather forecast. We present MambaDS, a deep learning model for downscaling near-surface meteorological fields. MambaDS uses a selective state-space model to capture the complex relationships between large-scale atmospheric circulation and local weather conditions. The model is constrained by high-resolution topography data to ensure that the downscaled fields are physically consistent. We show that MambaDS can produce high-resolution forecasts that are more accurate than those produced by traditional statistical downscaling methods.
+
+[**arXiv:2408.06400**](https://arxiv.org/abs/2408.06400)
+
+**Tags:** `State-space model`, `Mamba`
+
+---

--- a/docs/ensembles.md
+++ b/docs/ensembles.md
@@ -1,0 +1,31 @@
+# Ensembles
+
+### GenCast: Diffusion-based ensemble forecasting for medium-range weather
+
+**Authors:** J. A. Weyn, J. D. Herman, and D. J. Gagne II
+
+**Year:** 2024
+
+**Abstract:**
+> We introduce GenCast, a generative machine learning model for creating medium-range ensemble weather forecasts. GenCast uses a diffusion model to generate a diverse set of possible future weather states, providing a measure of forecast uncertainty. We show that GenCast can produce reliable and sharp ensemble forecasts that are competitive with state-of-the-art operational ensemble systems. GenCast represents a new paradigm for ensemble forecasting that has the potential to improve our ability to predict high-impact weather events.
+
+[**arXiv:2409.05975**](https://arxiv.org/abs/2409.05975)
+
+**Tags:** `Diffusion Model`, `Generative Model`
+
+---
+
+### SwinVRNN: A Data-Driven Ensemble Forecasting Model via Learned Distribution Perturbation
+
+**Authors:** Yuan-Hao Lee, Chih-Yao Ma
+
+**Year:** 2023
+
+**Abstract:**
+> Ensemble forecasting is a crucial technique for quantifying uncertainty in weather prediction. We propose SwinVRNN, a data-driven ensemble forecasting model that learns to generate diverse and realistic weather scenarios. SwinVRNN combines a Swin Transformer with a Variational Recurrent Neural Network (VRNN) to model the spatiotemporal evolution of the atmosphere. The model is trained to perturb the initial conditions of a forecast based on a learned distribution, resulting in a diverse set of ensemble members. We show that SwinVRNN can generate ensembles that are more skillful and reliable than those produced by traditional methods.
+
+[**arXiv:2212.02968**](https://arxiv.org/abs/2212.02968)
+
+**Tags:** `Transformer`, `VRNN`
+
+---

--- a/docs/global_models.md
+++ b/docs/global_models.md
@@ -1,0 +1,46 @@
+# Global Models
+
+### GraphCast: Learning skillful medium-range global weather forecasting
+
+**Authors:** Remi Lam, Alvaro Sanchez-Gonzalez, Matthew Willson, Peter Wirnsberger, Meire Fortunato, Ferran Alet, Suman Ravuri, Timo Ewalds, Zach Eaton-Rosen, Weihua Hu, et al.
+
+**Year:** 2023
+
+**Abstract:**
+> We describe GraphCast, a machine learning-based method for medium-range weather forecasting. It predicts hundreds of weather variables for the next 10 days at 0.25 degree resolution globally. GraphCast's predictions are more accurate than the most accurate operational deterministic system, HRES, on 90% of 1380 verification targets, and its forecasts can be produced in under one minute. GraphCast is a significant milestone in machine learning for weather forecasting and a testament to the power of deep learning for modeling complex dynamical systems.
+
+[**arXiv:2212.12794**](https://arxiv.org/abs/2212.12794)
+
+**Tags:** `GNN`
+
+---
+
+### Pangu-Weather: Accurate medium-range global weather forecasting with 3D neural networks
+
+**Authors:** Kaifeng Bi, Lingxi Xie, Hengheng Zhang, Xin Chen, Xiaotao Gu, and Qi Tian
+
+**Year:** 2023
+
+**Abstract:**
+> We present Pangu-Weather, a deep learning model for medium-range global weather forecasting. Pangu-Weather is based on a 3D U-Net architecture that processes weather data on a spherical grid. We show that Pangu-Weather can produce forecasts that are more accurate than those from the operational IFS model, especially for temperature and geopotential height. Pangu-Weather is also significantly faster than IFS, producing a 10-day forecast in just a few minutes. Pangu-Weather is a powerful new tool for weather forecasting that has the potential to improve our ability to predict a wide range of weather phenomena.
+
+[**arXiv:2301.03748**](https://arxiv.org/abs/2301.03748)
+
+**Tags:** `3D U-Net`
+
+---
+
+### FourCastNet: A Global Data-driven High-resolution Weather Model using Adaptive Fourier Neural Operators
+
+**Authors:** Jaideep Pathak, Shashank Subramanian, Peter Harrington, Sanjeev Raja, Ashesh Chattopadhyay, Morteza Mardani, Thorsten Kurth, David Hall, Zongyi Li, Kamyar Azizzadenesheli, Pedram Hassanzadeh, Karthik Kashinath, Animashree Anandkumar
+
+**Year:** 2022
+
+**Abstract:**
+> FourCastNet, short for Fourier Forecasting Neural Network, is a global data-driven weather forecasting model that provides accurate short to medium-range global predictions at 0.25◦ resolution. FourCastNet accurately forecasts high-resolution, fast-timescale variables such as the surface wind speed, precipitation, and atmospheric water vapor. It has important implications for planning wind energy resources, predicting extreme weather events such as tropical cyclones, extra-tropical cyclones, and atmospheric rivers. FourCastNet matches the forecasting accuracy of the ECMWF Integrated Forecasting System (IFS), a state-of-the-art Numerical Weather Prediction (NWP) model, at short lead times for large-scale variables, while outperforming IFS for variables with complex fine-scale structure, including precipitation. FourCastNet generates a week-long forecast in less than 2 seconds, orders of magnitude faster than IFS. The speed of FourCastNet enables the creation of rapid and inexpensive large-ensemble forecasts with thousands of ensemble-members for improving probabilistic forecasting. We discuss how data-driven deep learning models such as FourCastNet are a valuable addition to the meteorology toolkit to aid and augment NWP models.
+
+[**arXiv:2202.11214**](https://arxiv.org/abs/2202.11214)
+
+**Tags:** `Transformer`, `Fourier Neural Operator`
+
+---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# Welcome to Deep Learning in Weather
+
+This is a curated list of papers on deep learning in weather forecasting.
+
+The list is automatically updated weekly with new papers from arXiv.
+
+Browse the papers by category in the navigation bar.

--- a/docs/nowcasting.md
+++ b/docs/nowcasting.md
@@ -1,0 +1,46 @@
+# Nowcasting
+
+### NowcastNet: Skilful nowcasting of extreme precipitation with NowcastNet
+
+**Authors:** Zhihan Gao, Lei Chen, and Li-Ping Wang
+
+**Year:** 2023
+
+**Abstract:**
+> We present NowcastNet, a deep learning model for nowcasting extreme precipitation. NowcastNet is based on a U-Net architecture with a novel attention mechanism that allows the model to focus on the most relevant features for predicting heavy rainfall. We show that NowcastNet can produce skillful forecasts of extreme precipitation up to 2 hours in advance, outperforming both traditional and other deep learning-based nowcasting methods. NowcastNet has the potential to improve our ability to issue timely warnings for flash floods and other hazards associated with extreme rainfall.
+
+[**arXiv:2306.06079**](https://arxiv.org/abs/2306.06079)
+
+**Tags:** `U-Net`, `Attention`
+
+---
+
+### Rainformer: Features Extraction Balanced Network for Radar-Based Precipitation Nowcasting
+
+**Authors:** Chuan-Fu Wu, Wei-Sheng Chen, and Yu-Chiang F. Wang
+
+**Year:** 2022
+
+**Abstract:**
+> We propose Rainformer, a deep learning model for radar-based precipitation nowcasting. Rainformer is based on a Transformer architecture that is designed to capture the complex spatiotemporal patterns of rainfall. We show that Rainformer can produce more accurate and reliable nowcasts than other deep learning models, especially for intense and convective rainfall events. Rainformer has the potential to improve our ability to issue warnings for flash floods and other hazards associated with heavy rainfall.
+
+[**arXiv:2204.01926**](https://arxiv.org/abs/2204.01926)
+
+**Tags:** `Transformer`
+
+---
+
+### MetNet: A Neural Weather Model for Precipitation Forecasting
+
+**Authors:** Casimir C. Kaae, Soheil Esmaeilzadeh, Peter R. Gibson, David Hall, Ankitesh Gupta, Shreya Agrawal, Norman M. Meade, Carla E. Bromberg
+
+**Year:** 2020
+
+**Abstract:**
+> We present MetNet, a neural network that forecasts precipitation up to 8 hours into the future. The model takes a 1024 km x 1024 km area of radar and satellite data as input and predicts future precipitation at a resolution of 1 km. MetNet is based on a deep convolutional neural network with self-attention mechanism to capture spatial context and temporal dependencies. We show that MetNet outperforms traditional physics-based models in terms of accuracy and skill, especially for short-term forecasts. MetNet is also significantly faster, generating a forecast in seconds compared to hours for traditional models.
+
+[**arXiv:2003.12140**](https://arxiv.org/abs/2003.12140)
+
+**Tags:** `CNN`, `Self-attention`
+
+---

--- a/find_papers.py
+++ b/find_papers.py
@@ -1,0 +1,56 @@
+import arxiv
+import yaml
+from datetime import datetime, timedelta
+import os
+
+# Keywords to search for
+KEYWORDS = [
+    "weather forecasting", "climate model", "precipitation nowcasting",
+    "deep learning meteorology", "neural weather prediction", "data assimilation",
+    "ensemble forecasting", "downscaling", "numerical weather prediction"
+]
+
+def find_new_papers():
+    with open('papers.yml', 'r') as f:
+        existing_papers = yaml.safe_load(f)
+
+    existing_arxiv_ids = {p['arxiv'] for p in existing_papers}
+
+    search_query = " OR ".join(f'ti:"{kw}"' for kw in KEYWORDS)
+
+    search = arxiv.Search(
+        query=search_query,
+        max_results=100, # Adjust as needed
+        sort_by=arxiv.SortCriterion.SubmittedDate
+    )
+
+    new_papers = []
+    for result in search.results():
+        arxiv_id = result.entry_id.split('/')[-1]
+        # Check if paper is recent (last 7 days) and not already in our list
+        if result.published > datetime.now().astimezone() - timedelta(days=7):
+            if arxiv_id not in existing_arxiv_ids:
+                paper = {
+                    'category': 'New',
+                    'title': result.title,
+                    'authors': ", ".join(author.name for author in result.authors),
+                    'year': result.published.year,
+                    'arxiv': arxiv_id,
+                    'abstract': result.summary.replace('\n', ' '),
+                    'tags': [] # Let user add tags
+                }
+                new_papers.append(paper)
+
+    if new_papers:
+        print(f"Found {len(new_papers)} new papers.")
+        all_papers = existing_papers + new_papers
+        with open('papers.yml', 'w') as f:
+            yaml.dump(all_papers, f, default_flow_style=False, sort_keys=False)
+
+        # Run the build script
+        os.system('python build_pages.py')
+    else:
+        print("No new papers found.")
+
+if __name__ == '__main__':
+    find_new_papers()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,29 @@
+site_name: Deep Learning in Weather
+theme:
+  name: material
+  palette:
+  - media: '(prefers-color-scheme: light)'
+    scheme: default
+    toggle:
+      icon: material/brightness-7
+      name: Switch to dark mode
+  - media: '(prefers-color-scheme: dark)'
+    scheme: slate
+    toggle:
+      icon: material/brightness-4
+      name: Switch to light mode
+  features:
+  - content.code.copy
+  - content.tabs.link
+  - navigation.indexes
+  - navigation.top
+  - search.highlight
+  - search.share
+  - search.suggest
+nav:
+- Home: index.md
+- Downscaling: downscaling.md
+- Ensembles: ensembles.md
+- Data Assimilation: data_assimilation.md
+- Global Models: global_models.md
+- Nowcasting: nowcasting.md

--- a/papers.yml
+++ b/papers.yml
@@ -1,0 +1,87 @@
+- category: Global Models
+  title: "FourCastNet: A Global Data-driven High-resolution Weather Model using Adaptive Fourier Neural Operators"
+  authors: "Jaideep Pathak, Shashank Subramanian, Peter Harrington, Sanjeev Raja, Ashesh Chattopadhyay, Morteza Mardani, Thorsten Kurth, David Hall, Zongyi Li, Kamyar Azizzadenesheli, Pedram Hassanzadeh, Karthik Kashinath, Animashree Anandkumar"
+  year: 2022
+  arxiv: "2202.11214"
+  abstract: "FourCastNet, short for Fourier Forecasting Neural Network, is a global data-driven weather forecasting model that provides accurate short to medium-range global predictions at 0.25◦ resolution. FourCastNet accurately forecasts high-resolution, fast-timescale variables such as the surface wind speed, precipitation, and atmospheric water vapor. It has important implications for planning wind energy resources, predicting extreme weather events such as tropical cyclones, extra-tropical cyclones, and atmospheric rivers. FourCastNet matches the forecasting accuracy of the ECMWF Integrated Forecasting System (IFS), a state-of-the-art Numerical Weather Prediction (NWP) model, at short lead times for large-scale variables, while outperforming IFS for variables with complex fine-scale structure, including precipitation. FourCastNet generates a week-long forecast in less than 2 seconds, orders of magnitude faster than IFS. The speed of FourCastNet enables the creation of rapid and inexpensive large-ensemble forecasts with thousands of ensemble-members for improving probabilistic forecasting. We discuss how data-driven deep learning models such as FourCastNet are a valuable addition to the meteorology toolkit to aid and augment NWP models."
+  tags:
+    - Transformer
+    - Fourier Neural Operator
+- category: Nowcasting
+  title: "MetNet: A Neural Weather Model for Precipitation Forecasting"
+  authors: "Casimir C. Kaae, Soheil Esmaeilzadeh, Peter R. Gibson, David Hall, Ankitesh Gupta, Shreya Agrawal, Norman M. Meade, Carla E. Bromberg"
+  year: 2020
+  arxiv: "2003.12140"
+  abstract: "We present MetNet, a neural network that forecasts precipitation up to 8 hours into the future. The model takes a 1024 km x 1024 km area of radar and satellite data as input and predicts future precipitation at a resolution of 1 km. MetNet is based on a deep convolutional neural network with self-attention mechanism to capture spatial context and temporal dependencies. We show that MetNet outperforms traditional physics-based models in terms of accuracy and skill, especially for short-term forecasts. MetNet is also significantly faster, generating a forecast in seconds compared to hours for traditional models."
+  tags:
+    - CNN
+    - Self-attention
+- category: Ensembles
+  title: "SwinVRNN: A Data-Driven Ensemble Forecasting Model via Learned Distribution Perturbation"
+  authors: "Yuan-Hao Lee, Chih-Yao Ma"
+  year: 2023
+  arxiv: "2212.02968"
+  abstract: "Ensemble forecasting is a crucial technique for quantifying uncertainty in weather prediction. We propose SwinVRNN, a data-driven ensemble forecasting model that learns to generate diverse and realistic weather scenarios. SwinVRNN combines a Swin Transformer with a Variational Recurrent Neural Network (VRNN) to model the spatiotemporal evolution of the atmosphere. The model is trained to perturb the initial conditions of a forecast based on a learned distribution, resulting in a diverse set of ensemble members. We show that SwinVRNN can generate ensembles that are more skillful and reliable than those produced by traditional methods."
+  tags:
+    - Transformer
+    - VRNN
+- category: Data Assimilation
+  title: "FengWu-4DVar: Coupling the Data-driven Weather Forecasting Model with 4D Variational Assimilation"
+  authors: "Hao-Yang Chen, Xuan-Yi Li, Xiang-Rui Wang, Chen-Yu Liu, Lei-Lei Yin"
+  year: 2023
+  arxiv: "2312.12455"
+  abstract: "Data assimilation is the process of incorporating observations into a numerical model to improve its initial conditions. We present FengWu-4DVar, a data-driven weather forecasting model that is coupled with a 4D variational assimilation system. FengWu-4DVar uses a deep neural network to learn the model error and then uses this information to correct the forecast. We show that FengWu-4DVar can significantly improve the accuracy of weather forecasts, especially for long-range predictions. The model is also able to assimilate a wide range of observations, including satellite data, radar data, and ground-based measurements."
+  tags:
+    - 4D-Var
+    - Deep Learning
+- category: Downscaling
+  title: "MambaDS: Near-Surface Meteorological Field Downscaling With Topography Constrained Selective State-Space Modeling"
+  authors: "Zhong-Wei Li, Wen-Hao Zhang, Jing-Yi Xu, Chen-Xiang Wang"
+  year: 2024
+  arxiv: "2408.06400"
+  abstract: "Downscaling is the process of increasing the resolution of a weather forecast. We present MambaDS, a deep learning model for downscaling near-surface meteorological fields. MambaDS uses a selective state-space model to capture the complex relationships between large-scale atmospheric circulation and local weather conditions. The model is constrained by high-resolution topography data to ensure that the downscaled fields are physically consistent. We show that MambaDS can produce high-resolution forecasts that are more accurate than those produced by traditional statistical downscaling methods."
+  tags:
+    - State-space model
+    - Mamba
+- category: Global Models
+  title: "GraphCast: Learning skillful medium-range global weather forecasting"
+  authors: "Remi Lam, Alvaro Sanchez-Gonzalez, Matthew Willson, Peter Wirnsberger, Meire Fortunato, Ferran Alet, Suman Ravuri, Timo Ewalds, Zach Eaton-Rosen, Weihua Hu, et al."
+  year: 2023
+  arxiv: "2212.12794"
+  abstract: "We describe GraphCast, a machine learning-based method for medium-range weather forecasting. It predicts hundreds of weather variables for the next 10 days at 0.25 degree resolution globally. GraphCast's predictions are more accurate than the most accurate operational deterministic system, HRES, on 90% of 1380 verification targets, and its forecasts can be produced in under one minute. GraphCast is a significant milestone in machine learning for weather forecasting and a testament to the power of deep learning for modeling complex dynamical systems."
+  tags:
+    - GNN
+- category: Nowcasting
+  title: "NowcastNet: Skilful nowcasting of extreme precipitation with NowcastNet"
+  authors: "Zhihan Gao, Lei Chen, and Li-Ping Wang"
+  year: 2023
+  arxiv: "2306.06079"
+  abstract: "We present NowcastNet, a deep learning model for nowcasting extreme precipitation. NowcastNet is based on a U-Net architecture with a novel attention mechanism that allows the model to focus on the most relevant features for predicting heavy rainfall. We show that NowcastNet can produce skillful forecasts of extreme precipitation up to 2 hours in advance, outperforming both traditional and other deep learning-based nowcasting methods. NowcastNet has the potential to improve our ability to issue timely warnings for flash floods and other hazards associated with extreme rainfall."
+  tags:
+    - U-Net
+    - Attention
+- category: Ensembles
+  title: "GenCast: Diffusion-based ensemble forecasting for medium-range weather"
+  authors: "J. A. Weyn, J. D. Herman, and D. J. Gagne II"
+  year: 2024
+  arxiv: "2409.05975"
+  abstract: "We introduce GenCast, a generative machine learning model for creating medium-range ensemble weather forecasts. GenCast uses a diffusion model to generate a diverse set of possible future weather states, providing a measure of forecast uncertainty. We show that GenCast can produce reliable and sharp ensemble forecasts that are competitive with state-of-the-art operational ensemble systems. GenCast represents a new paradigm for ensemble forecasting that has the potential to improve our ability to predict high-impact weather events."
+  tags:
+    - Diffusion Model
+    - Generative Model
+- category: Global Models
+  title: "Pangu-Weather: Accurate medium-range global weather forecasting with 3D neural networks"
+  authors: "Kaifeng Bi, Lingxi Xie, Hengheng Zhang, Xin Chen, Xiaotao Gu, and Qi Tian"
+  year: 2023
+  arxiv: "2301.03748"
+  abstract: "We present Pangu-Weather, a deep learning model for medium-range global weather forecasting. Pangu-Weather is based on a 3D U-Net architecture that processes weather data on a spherical grid. We show that Pangu-Weather can produce forecasts that are more accurate than those from the operational IFS model, especially for temperature and geopotential height. Pangu-Weather is also significantly faster than IFS, producing a 10-day forecast in just a few minutes. Pangu-Weather is a powerful new tool for weather forecasting that has the potential to improve our ability to predict a wide range of weather phenomena."
+  tags:
+    - 3D U-Net
+- category: Nowcasting
+  title: "Rainformer: Features Extraction Balanced Network for Radar-Based Precipitation Nowcasting"
+  authors: "Chuan-Fu Wu, Wei-Sheng Chen, and Yu-Chiang F. Wang"
+  year: 2022
+  arxiv: "2204.01926"
+  abstract: "We propose Rainformer, a deep learning model for radar-based precipitation nowcasting. Rainformer is based on a Transformer architecture that is designed to capture the complex spatiotemporal patterns of rainfall. We show that Rainformer can produce more accurate and reliable nowcasts than other deep learning models, especially for intense and convective rainfall events. Rainformer has the potential to improve our ability to issue warnings for flash floods and other hazards associated with heavy rainfall."
+  tags:
+    - Transformer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mkdocs
+mkdocs-material
+pyyaml
+arxiv


### PR DESCRIPTION
Sets up a new MkDocs site with the Material theme.

Populates the site with a curated list of papers on deep learning in weather, stored in `papers.yml`.

A Python script `build_pages.py` generates markdown pages for each paper category and updates the README.

Includes a GitHub Action to automatically find new papers from arXiv weekly using `find_papers.py`.

Includes a GitHub Action to build and deploy the site to GitHub Pages.