### PR TITLE
fix: add write permissions to update workflow

### DIFF
--- a/.github/workflows/update_papers.yml
+++ b/.github/workflows/update_papers.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
This commit adds the `permissions: contents: write` to the `update_papers.yml` workflow. This is necessary to allow the workflow to commit and push changes to the repository.

This commit is on top of the previous work to create the website.