### PR TITLE
fix: add write permissions to github actions workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
This commit adds the `permissions: contents: write` to both the `deploy.yml` and `update_papers.yml` workflows.

This is necessary to allow the workflows to commit and push changes to the repository.